### PR TITLE
ログイン前の各種画面の作成

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "php": "^7.1.3",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.8.*",
-        "laravel/tinker": "^1.0"
+        "laravel/tinker": "^1.0",
+        "laravelcollective/html": "5.8"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94d4bf9ac7f4a933030e46a346ee2917",
+    "content-hash": "f007c1ed9c5cb3a7a237397ed873efbf",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -769,6 +769,74 @@
                 "source": "https://github.com/laravel/tinker/tree/v1.0.10"
             },
             "time": "2019-08-07T15:10:45+00:00"
+        },
+        {
+            "name": "laravelcollective/html",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LaravelCollective/html.git",
+                "reference": "0e360143d3476fe4141d267a260c140569fa207b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LaravelCollective/html/zipball/0e360143d3476fe4141d267a260c140569fa207b",
+                "reference": "0e360143d3476fe4141d267a260c140569fa207b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "5.8.*",
+                "illuminate/routing": "5.8.*",
+                "illuminate/session": "5.8.*",
+                "illuminate/support": "5.8.*",
+                "illuminate/view": "5.8.*",
+                "php": ">=7.1.3"
+            },
+            "require-dev": {
+                "illuminate/database": "5.8.*",
+                "mockery/mockery": "~1.0",
+                "phpunit/phpunit": "~7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.8-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Collective\\Html\\HtmlServiceProvider"
+                    ],
+                    "aliases": {
+                        "Form": "Collective\\Html\\FormFacade",
+                        "Html": "Collective\\Html\\HtmlFacade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Collective\\Html\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                },
+                {
+                    "name": "Adam Engebretson",
+                    "email": "adam@laravelcollective.com"
+                }
+            ],
+            "description": "HTML and Form Builders for the Laravel Framework",
+            "homepage": "https://laravelcollective.com",
+            "time": "2019-03-01T22:53:41+00:00"
         },
         {
             "name": "league/flysystem",
@@ -5774,5 +5842,5 @@
         "php": "^7.1.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/resources/views/auth/confirm.blade.php
+++ b/resources/views/auth/confirm.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <h5 class="p-3 mt-5 mb-2 bg-primary text-light text-center">会員登録確認画面</h5>
+      <div class="card mb-5">
+        <div class="card-body">
+
+          @csrf
+
+          <div class="row mt-5 mb-5">
+            <div class="col-sm-8 offset-sm-2">
+
+              {!! Form::open([ 'method' => 'post']) !!}
+              <div class="form-group">
+                {!! Form::label('name', 'お名前') !!}
+                {!! Form::text('name', old('name'), ['class' => 'form-control','readonly']) !!}
+              </div>
+
+              <div class="form-group">
+                {!! Form::label('email', 'メールアドレス') !!}
+                {!! Form::text('email', old('email'), ['class' => 'form-control','readonly']) !!}
+              </div>
+
+              <div class="form-group">
+                <label for="password">パスワード</label>
+                <input id="password" type="hidden" name="password" class="form-control" value="{{ old('password') }}">
+                <input id="password" type="password" name="password" class="form-control" value="{{ old('password') }}" disabled>
+              </div>
+
+
+
+              {!! Form::submit('登録する', ['name' => 'action', 'class' => 'btn btn-primary mt-5 p-2  btn-block']) !!}
+              {!! Form::submit('戻る', ['name' => 'action', 'class' => 'btn btn-secondary mt-3 p-2  btn-block']) !!}
+              {!! Form::close() !!}
+
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <h5 class="p-3 mt-5 mb-2 bg-primary text-light text-center">ログイン</h5>
+            <div class="card mb-5">
+                <div class="card-body">
+
+                    @csrf
+
+                    <div class="row mt-5 mb-5">
+                        <div class="col-sm-8 offset-sm-2">
+                            {!! Form::open([]) !!}
+
+
+                            <div class="form-group">
+                                {!! Form::label('email', 'メールアドレス') !!}
+                                {!! Form::email('email', old('email'), ['class' => 'form-control', 'placeholder' => '例）hakkutsu@example.com']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('email') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            </ul>
+                            @endif
+
+
+                            <div class="form-group">
+                                {!! Form::label('password', 'パスワード') !!}
+                                {!! Form::password('password', ['class' => 'form-control', 'placeholder' => '半角英数字６文字以上']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            </ul>
+                            @endif
+
+                            <div class="form-group row">
+                                <div class="col-md-12">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
+
+                                        <label class="form-check-label" for="remember">
+                                            {{ __('メールアドレスを記憶する') }}
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {!! Form::submit('ログイン', ['class' => 'btn btn-primary mt-5 p-2 btn-block']) !!}
+                            {!! Form::close() !!}
+
+                            @if (Route::has('password.request'))
+                            <a class="btn btn-link" href="{{ route('password.request') }}">
+                                {{ __('パスワードをお忘れですか？') }}
+                            </a>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/register_elementary.blade.php
+++ b/resources/views/auth/register_elementary.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <h5 class="p-3 mt-5 mb-2 bg-primary text-light text-center">無料会員登録</h5>
+            <div class="card mb-5">
+                <div class="card-body">
+
+                    @csrf
+
+                    <div class="row mt-5 mb-5">
+                        <div class="col-sm-8 offset-sm-2">
+
+                            {!! Form::open(['method' => 'post']) !!}
+                            <div class="form-group">
+                                {!! Form::label('name', 'アカウント名') !!}
+                                {!! Form::text('name', old('name'), ['class' => 'form-control', 'placeholder' => '例）学園 太郎']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('name') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+                            <div class="form-group">
+                                {!! Form::label('email', 'メールアドレス') !!}
+                                {!! Form::email('email', old('email'), ['class' => 'form-control', 'placeholder' => '例）flatstyle@example.com']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('email') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password', 'パスワード') !!}
+                                {!! Form::password('password', ['class' => 'form-control', 'placeholder' => '半角英数字６文字以上']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password_confirmation', 'パスワード（確認）') !!}
+                                {!! Form::password('password_confirmation', ['class' => 'form-control', 'placeholder' => '再度入力してください']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password_confirmation') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+
+                            {!! Form::submit('確認する', ['class' => 'btn btn-primary mt-5 p-2 btn-block']) !!}
+                            {!! Form::close() !!}
+
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/register_high.blade.php
+++ b/resources/views/auth/register_high.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <h5 class="p-3 mt-5 mb-2 bg-primary text-light text-center">私立探求学園（高等生）登録</h5>
+            <div class="card mb-5">
+                <div class="card-body">
+
+                    @csrf
+
+                    <div class="row mt-5 mb-5">
+                        <div class="col-sm-8 offset-sm-2">
+
+                            {!! Form::open(['method' => 'post']) !!}
+                            <div class="form-group">
+                                {!! Form::label('name', 'アカウント名') !!}
+                                {!! Form::text('name', old('name'), ['class' => 'form-control', 'placeholder' => '例）学園 太郎']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('name') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+                            <div class="form-group">
+                                {!! Form::label('email', 'メールアドレス') !!}
+                                {!! Form::email('email', old('email'), ['class' => 'form-control', 'placeholder' => '例）flatstyle@example.com']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('email') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password', 'パスワード') !!}
+                                {!! Form::password('password', ['class' => 'form-control', 'placeholder' => '半角英数字６文字以上']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password_confirmation', 'パスワード（確認）') !!}
+                                {!! Form::password('password_confirmation', ['class' => 'form-control', 'placeholder' => '再度入力してください']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password_confirmation') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+
+                            {!! Form::submit('確認する', ['class' => 'btn btn-primary mt-5 p-2 btn-block']) !!}
+                            {!! Form::close() !!}
+
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/register_middle_laravel.blade.php
+++ b/resources/views/auth/register_middle_laravel.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <h5 class="p-3 mt-5 mb-2 bg-primary text-light text-center">LaravelQuest生（中等部）登録</h5>
+            <div class="card mb-5">
+                <div class="card-body">
+
+                    @csrf
+
+                    <div class="row mt-5 mb-5">
+                        <div class="col-sm-8 offset-sm-2">
+
+                            {!! Form::open(['method' => 'post']) !!}
+                            <div class="form-group">
+                                {!! Form::label('name', 'アカウント名') !!}
+                                {!! Form::text('name', old('name'), ['class' => 'form-control', 'placeholder' => '例）学園 太郎']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('name') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+                            <div class="form-group">
+                                {!! Form::label('email', 'メールアドレス') !!}
+                                {!! Form::email('email', old('email'), ['class' => 'form-control', 'placeholder' => '例）flatstyle@example.com']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('email') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password', 'パスワード') !!}
+                                {!! Form::password('password', ['class' => 'form-control', 'placeholder' => '半角英数字６文字以上']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password_confirmation', 'パスワード（確認）') !!}
+                                {!! Form::password('password_confirmation', ['class' => 'form-control', 'placeholder' => '再度入力してください']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password_confirmation') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+
+                            {!! Form::submit('確認する', ['class' => 'btn btn-primary mt-5 p-2 btn-block']) !!}
+                            {!! Form::close() !!}
+
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/register_middle_rails.blade.php
+++ b/resources/views/auth/register_middle_rails.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <h5 class="p-3 mt-5 mb-2 bg-primary text-light text-center">Rails指導生（中等部）登録</h5>
+            <div class="card mb-5">
+                <div class="card-body">
+
+                    @csrf
+
+                    <div class="row mt-5 mb-5">
+                        <div class="col-sm-8 offset-sm-2">
+
+                            {!! Form::open(['method' => 'post']) !!}
+                            <div class="form-group">
+                                {!! Form::label('name', 'アカウント名') !!}
+                                {!! Form::text('name', old('name'), ['class' => 'form-control', 'placeholder' => '例）学園 太郎']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('name') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+                            <div class="form-group">
+                                {!! Form::label('email', 'メールアドレス') !!}
+                                {!! Form::email('email', old('email'), ['class' => 'form-control', 'placeholder' => '例）flatstyle@example.com']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('email') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password', 'パスワード') !!}
+                                {!! Form::password('password', ['class' => 'form-control', 'placeholder' => '半角英数字６文字以上']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password_confirmation', 'パスワード（確認）') !!}
+                                {!! Form::password('password_confirmation', ['class' => 'form-control', 'placeholder' => '再度入力してください']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password_confirmation') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+
+                            {!! Form::submit('確認する', ['class' => 'btn btn-primary mt-5 p-2 btn-block']) !!}
+                            {!! Form::close() !!}
+
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/berore_login/toppage.blade.php
+++ b/resources/views/berore_login/toppage.blade.php
@@ -11,82 +11,28 @@
 
 
 <div class="container">
-  <h2 class="text-center mt-5 mb-5 p-3 text-dark">どこで学ぶ?<br>ー Category ー</h2>
-  <div class="card-deck row">
+  <h3 class="text-center mt-4 mb-4 p-3"> Flatstyleとは </h3>
+  <p class="text-center mb-5 under_line">
+  知識を集積し、学習を支援する図書館です。  
+  </p>
 
-    <div class="col-md-6 col-lg-4 mb-4">
-      <div class="card">
-        <img class="card-img-top store-display" src="{{ asset('images/book1.jpg') }}" alt="top">
-        <div class="card-body">
-          <h5 class="card-title">カテゴリー1</h5>
-          <p class="card-text">
-            カテゴリーの説明が入ります。カテゴリーの説明が入ります。
-          </p>
-        </div>
-      </div>
-    </div>
+  <p class="text-center mb-5">
+    私立探求学園で作成した動画やテキストを<br>
+    一箇所にまとめ公開しています。
+  </p>
 
-    <div class="col-md-6 col-lg-4 mb-4">
-      <div class="card">
-        <img class="card-img-top store-display" src="{{ asset('images/book1.jpg') }}" alt="top">
-        <div class="card-body">
-          <h5 class="card-title">カテゴリー2</h5>
-          <p class="card-text">
-            カテゴリーの説明が入ります。カテゴリーの説明が入ります。
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-6 col-lg-4 mb-4">
-      <div class="card">
-        <img class="card-img-top store-display" src="{{ asset('images/book1.jpg') }}" alt="top">
-        <div class="card-body">
-          <h5 class="card-title">カテゴリー3</h5>
-          <p class="card-text">
-            カテゴリーの説明が入ります。カテゴリーの説明が入ります。
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-6 col-lg-4 mb-4">
-      <div class="card">
-        <img class="card-img-top store-display" src="{{ asset('images/book1.jpg') }}" alt="top">
-        <div class="card-body">
-          <h5 class="card-title">カテゴリー4</h5>
-          <p class="card-text">
-            カテゴリーの説明が入ります。カテゴリーの説明が入ります。
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-6 col-lg-4 mb-4">
-      <div class="card">
-        <img class="card-img-top store-display" src="{{ asset('images/book1.jpg') }}" alt="top">
-        <div class="card-body">
-          <h5 class="card-title">カテゴリー5</h5>
-          <p class="card-text">
-            カテゴリーの説明が入ります。カテゴリーの説明が入ります。
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-6 col-lg-4 mb-4">
-      <div class="card">
-        <img class="card-img-top store-display" src="{{ asset('images/book1.jpg') }}" alt="top">
-        <div class="card-body">
-          <h5 class="card-title">カテゴリー6</h5>
-          <p class="card-text">
-            カテゴリーの説明が入ります。カテゴリーの説明が入ります。
-          </p>
-        </div>
-      </div>
-    </div>
-
-  </div>
+  <p class="text-center mb-5">
+    ・転職成功者やフリーランスが役立てた資料も追加していきます。<br>
+    ・これからどんどん機能拡充していきます。
+  </p>
+  <p class="text-center mb-5">
+    是非一度足を運んでみて下さい。
+  </p>
+  <p class="text-center mb-5">
+    無料会員登録はこちらです<br>
+    ↓<br>
+    <a class="btn btn-primary btn-lg" href="#" role="button">無料会員登録</a>
+  </p>
 </div>
 
 @endsection

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-md  navbar-dark bg-primary">
-  <a class="navbar-brand" href="/"><img src="images/flatstyle.title.png" width="125 alt="flatstyle.title.png"></a>
+  <a class="navbar-brand" href="/"><img src="/images/flatstyle.title.png" width="125 alt="flatstyle.title.png"></a>
   <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#bs-navi" aria-controls="bs-navi" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -40,11 +40,19 @@
     background-color: #1c4587;
 }
 
+.btn-primary {
+    background-color: #1c4587;
+    border-color: #1c4587;
+}
+
+.under_line {
+  text-decoration : underline;
+}
+
 /* ヘッダーのプルダウンのフォントを白色に*/
 .dropdown-item {
     color: #FFFFFF;
 }
-    </style>
     </style>
 </head>
 <body>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -43,6 +43,13 @@
 .btn-primary {
     background-color: #1c4587;
     border-color: #1c4587;
+    border-radius: 100px;
+}
+
+.btn-secondary{
+    background-color: #E05A0E;
+    border-color: #E05A0E;
+    border-radius: 100px;
 }
 
 .under_line {

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,9 +11,37 @@
 |
 */
 
+
 //ログイン前のトップページ 
 Route::get('/', function () {
     return view('berore_login.toppage');
+});
+
+//登録画面（高等部・中等部（Laravel・Rails）・初等部(無料)）
+Route::get('/register/high', function () {
+    return view('auth.register_high');
+});
+
+Route::get('/register/middle/laravel', function () {
+    return view('auth.register_middle_laravel');
+});
+
+Route::get('/register/middle/rails', function () {
+    return view('auth.register_middle_rails');
+});
+
+Route::get('/register/elementary', function () {
+    return view('auth.register_elementary');
+});
+
+//登録確認画面
+Route::get('/register/confirm', function () {
+    return view('auth.confirm');
+});
+
+//ログイン画面
+Route::get('/login', function () {
+    return view('auth.login');
 });
 
 //ログイン後のトップページ


### PR DESCRIPTION
ログイン画面のトップ画面、
4種の登録画面（高等部、中等部(Laravel・Rails)、初等部）、
登録確認画面、
ログイン画面、
の作成を行いました。

報告事項
①入力フォーム作成のために、laravel collectiveをインストールしているので、composer installをお願い致します。
②ヘッダーについては、ログイン後の表示になっています。ユーザー登録、ログイン実装後にログイン前のヘッダーを作成する予定です。
③登録画面のフォームにエラー吐き出し用の記述を今後の実装のために残しておりますが、今は特に気にせず使っていただけると幸いです。

以上、よろしくお願いします。