### PR TITLE
コンテンツ関連の画面を作成

### DIFF
--- a/public/css/library.css
+++ b/public/css/library.css
@@ -1,0 +1,46 @@
+#library_delete ul{
+  margin: auto;
+  list-style: none;
+  display: flex;
+  width: 70%;
+  padding-left: 0px;
+  text-align: center;
+  }
+
+  #library_delete li{
+  display: inline;
+  margin: 50px auto;
+  width: 40%;
+  }
+
+  #library_delete li a{
+  display: block;
+  border: 1px solid #020811;
+  background-color: red;
+  text-decoration: none;
+  color: #ffffff;
+  padding: 20px 0;
+  text-align: center;
+  font-size: 20px;
+  width: 100%;
+  height: 80px;
+  }
+
+  #library_delete li a:hover{
+  border: 1px solid #020811;
+  background-color:  red;
+  }
+
+  li#library_delete_2 a{
+    background-color: #2d2d2d;
+  }
+
+  li#library_delete_2 a:hover{
+    border: 1px solid #020811;
+    background-color: #4d4d4d;
+  }
+
+  .delete_contents{
+    text-align: center;
+    margin: 60px auto;
+  }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,17 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    
+
     <title>Flatstyle</title>
 
     <!-- CSS -->
     <link rel="stylesheet" href="{{ asset('/css/style.css') }}">
     <!-- Bootstrap CDN -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
-    
+
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
@@ -21,6 +21,8 @@
 
     <!-- 「マイページ画面」のスタイルシート -->
     <link href="{{ asset('css/mypage.css') }}" rel="stylesheet">
+    <!-- 「コンテンツ削除画面」のスタイルシート -->
+    <link href="{{ asset('css/library.css') }}" rel="stylesheet">
 
     <style>
 

--- a/resources/views/library/library_confirm.blade.php
+++ b/resources/views/library/library_confirm.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+
+  <div id="menu_1">
+    <ul>
+      <li><a href="#">コンテンツ削除確認画面</a></li>
+    </ul>
+  </div>
+    <p class="delete_contents">コンテンツを本当に削除よろしいですか。</p>
+  <div id="library_delete">
+    <ul>
+        <li ><a  href="#">削除する</a></li>
+        <li id="library_delete_2"><a href="#">削除しない</a></li>
+    </ul>
+  </div>
+@endsection

--- a/resources/views/library/library_create.blade.php
+++ b/resources/views/library/library_create.blade.php
@@ -1,0 +1,70 @@
+@extends('layouts.app')
+
+@section('content')
+
+    <div id="menu_1">
+        <ul>
+            <li><a href="#">ユーザー情報の編集</a></li>
+        </ul>
+    </div>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                @csrf
+                <div class="card mb-5">
+                    <div class="card-body">
+                        @csrf
+                        <div class="row mt-5 mb-5">
+                            <div class="col-sm-8 offset-sm-2">
+
+                                {!! Form::open(['method' => 'post']) !!}
+                                <div class="form-group">
+                                    {!! Form::label('title', 'タイトル') !!}
+                                    {!! Form::text('title', old('title'), ['class' => 'form-control', 'placeholder' => '例）git勉強会']) !!}
+                                </div>
+                                @if (count($errors) > 0)
+                                    @foreach ($errors->get('title') as $error)
+                                        <div class="text-danger">{{ $error }}</div>
+                                    @endforeach
+                                @endif
+                                <div class="form-group">
+                                    {!! Form::label('url', 'URL') !!}
+                                    {!! Form::url('url', old('url'), ['class' => 'form-control', 'placeholder' => '例）https://www.youtube.com/']) !!}
+                                </div>
+                                @if (count($errors) > 0)
+                                    @foreach ($errors->get('url') as $error)
+                                        <div class="text-danger">{{ $error }}</div>
+                                    @endforeach
+                                @endif
+
+                                <div class="form-group">
+                                    {!! Form::label('password', '説明') !!}
+                                    {{Form::textarea('textareaRemarks', null, ['class' => 'form-control', 'id' => 'textareaRemarks', 'placeholder' => '説明', 'rows' => '10'])}}
+                                </div>
+                                @if (count($errors) > 0)
+                                    @foreach ($errors->get('password') as $error)
+                                        <div class="text-danger">{{ $error }}</div>
+                                    @endforeach
+                                @endif
+
+                                <div class="form-group">
+                                    {!! Form::label('category', 'カテゴリー') !!}
+                                    {{Form::select('category', [''=>'選択してください','javascript' => 'Javascript', 'php' => 'PHP', 'ruby' => 'Ruby', 'aws' => 'AWS', 'git' => 'Git'], '',  ['class' => 'form-control','id' => 'category'])}}
+                                </div>
+                                @if (count($errors) > 0)
+                                    @foreach ($errors->get('password_confirmation') as $error)
+                                        <div class="text-danger">{{ $error }}</div>
+                                    @endforeach
+                                @endif
+
+                                {!! Form::submit('登録する', ['class' => 'btn btn-primary mt-5 p-2 btn-block']) !!}
+                                {!! Form::submit('戻る', ['class' => 'btn btn-primary mt-4 p-2 btn-block']) !!}
+                                {!! Form::close() !!}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/library/library_edit.blade.php
+++ b/resources/views/library/library_edit.blade.php
@@ -1,0 +1,72 @@
+@extends('layouts.app')
+
+@section('content')
+
+  <div id="menu_1">
+    <ul>
+      <li><a href="#">ユーザー情報の編集</a></li>
+    </ul>
+  </div>
+  <div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+          @csrf
+          <div class="card mb-5">
+                <div class="card-body">
+                    @csrf
+                    <div class="row mt-5 mb-5">
+                        <div class="col-sm-8 offset-sm-2">
+
+                            {!! Form::open(['method' => 'post']) !!}
+                            <div class="form-group">
+                                {!! Form::label('title', 'タイトル') !!}
+                                {!! Form::text('title', old('title'), ['class' => 'form-control', 'placeholder' => '例）git勉強会']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('title') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+                            <div class="form-group">
+                                {!! Form::label('url', 'URL') !!}
+                                {!! Form::url('url', old('url'), ['class' => 'form-control', 'placeholder' => '例）https://www.youtube.com/']) !!}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('url') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('password', '説明') !!}
+                                {{Form::textarea('textareaRemarks', null, ['class' => 'form-control', 'id' => 'textareaRemarks', 'placeholder' => '説明', 'rows' => '10'])}}
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            <div class="form-group">
+                                {!! Form::label('category', 'カテゴリー') !!}
+                                {{Form::select('category', [''=>'選択してください','javascript' => 'Javascript', 'php' => 'PHP', 'ruby' => 'Ruby', 'aws' => 'AWS', 'git' => 'Git'], '',  ['class' => 'form-control','id' => 'category'])}}
+
+                            </div>
+                            @if (count($errors) > 0)
+                            @foreach ($errors->get('password_confirmation') as $error)
+                            <div class="text-danger">{{ $error }}</div>
+                            @endforeach
+                            @endif
+
+                            {!! Form::submit('編集する', ['class' => 'btn btn-primary mt-5 p-2 btn-block']) !!}
+                            {!! Form::submit('戻る', ['class' => 'btn btn-primary mt-4 p-2 btn-block']) !!}
+                            {!! Form::submit('削除する', ['class' => 'btn btn-danger mt-4 p-2 btn-block']) !!}
+                            {!! Form::close() !!}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@
 */
 
 
-//ログイン前のトップページ 
+//ログイン前のトップページ
 Route::get('/', function () {
     return view('berore_login.toppage');
 });
@@ -58,3 +58,15 @@ Route::get('/mypage/rankup/confirm', function (){return view('mypage.rank_up_con
 Route::get('/mypage/rankup/complete', function (){return view('mypage.rank_up_complete');})->name('mypage.rank_up_complete');
 Route::get('/mypage/memberlist', function (){return view('mypage.member_list');})->name('mypage.member');
 Route::get('/mypage/memberlist/edit', function (){return view('mypage.member_list_edit');})->name('member_list_delete');
+
+Route::get('/top/contents/create', function () {
+    return view('library.library_create');
+});
+
+Route::get('/top/contents/confirm', function () {
+    return view('library.library_confirm');
+});
+
+Route::get('/top/contents/edit', function () {
+    return view('library.library_edit');
+});


### PR DESCRIPTION
## コンテンツ関連の画面を作成
お手すきの際にご確認お願いいたします。
詳細は以下のとおりです
### 詳細
今回追加したものはコンテンツ画面の作成画面・編集画面・コンテンツ削除画面と対応する
CSSを追加しています。

``` 
public/css/library.css
resources/views/library/library_confirm.blade.php
resources/views/library/library_create.blade.php
resources/views/library/library_edit.blade.php 
```
routes/web.phpと resources/views/layouts/app.blade.phpを追記しています
web.php　　　はコンテンツ画面を見れるよう追記しています。
app.blade.php はpublic/css/library.cssを利用するためにheadタグに追記しています。